### PR TITLE
minSdk and targetSdk properties must be supported too

### DIFF
--- a/src/codenarc-converter/CodeNarc/src/main/groovy/org/codenarc/rule/ecocode/SupportedVersionRangeRule.groovy
+++ b/src/codenarc-converter/CodeNarc/src/main/groovy/org/codenarc/rule/ecocode/SupportedVersionRangeRule.groovy
@@ -41,7 +41,7 @@ class SupportedVersionRangeAstVisitor extends AbstractAstVisitor {
     @Override
     void visitMethodCallExpression(MethodCallExpression methodCallExpression) {
         def methodName = ((ConstantExpression) methodCallExpression.getMethod()).getValue()
-        if (methodName == 'minSdkVersion' || methodName == 'targetSdkVersion') {
+        if (methodName == 'minSdkVersion' || methodName == 'targetSdkVersion') { //TODO : minSdk and targetSdk must be supported too
             def arguments = AstUtil.getArgumentsValue(methodCallExpression.getArguments())
             if (arguments.size() == 1) {
                 rule[methodName] = arguments.get(0)


### PR DESCRIPTION
This detection rule triggers on `minSdkVersion` and `targetSdkVersion` but their variants `minSdk` and `targetSdk` are ignored. This has to be fixed.