### PR TITLE
SonarQube ecoCode-mobile container image

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -1,0 +1,75 @@
+---
+# template source: https://github.com/bretfisher/docker-build-workflow/blob/main/templates/call-docker-build.yaml
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+#  pull_request:
+#    branches:
+#      - main
+
+env:
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: sonarqube-ecocode-mobile
+  IMAGES: |
+    ghcr.io/${{ github.repository_owner }}/sonarqube-ecocode-mobile
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: ${{ env.IMAGES }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=semver,event=tag,pattern={{version}}
+            type=semver,event=tag,pattern={{major}}.{{minor}}
+            type=semver,event=tag,pattern={{major}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+
+      - name: Publish image
+        id: push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          pull: true
+          cache-to: type=gha,mode=max
+          cache-from: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
+FROM maven:3-openjdk-11-slim AS builder
+
+COPY . /usr/src/ecocode
+
+WORKDIR /usr/src/ecocode
+RUN ./tool_prepare-codenarc
+RUN ./tool_build.sh
+
 FROM sonarqube:9.9-community
 USER root
 ADD https://github.com/insideapp-oss/sonar-apple/releases/download/0.3.0/sonar-apple-plugin-0.3.0.jar /opt/sonarqube/extensions/plugins/sonar-apple-plugin-0.3.0.jar
 RUN chmod 777 /opt/sonarqube/extensions/plugins/sonar-apple-plugin-0.3.0.jar
+COPY --from=builder /usr/src/ecocode/lib/* /opt/sonarqube/extensions/plugins/
+
 USER sonarqube

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-openjdk-11-slim AS builder
+FROM maven:3.8-openjdk-11-slim AS builder
 
 COPY . /usr/src/ecocode
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ docker run -ti --rm \
        -v sq_ecocode_mobile_data:/opt/sonarqube/data \
        -p 9000:9000 \
        --name sonarqube-ecocode-mobile  \
-       --pull \
        ghcr.io/green-code-initiative/sonarqube-ecocode-mobile:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ ecoCode mobile is based on evolving catalogs of [best practices](https://github.
 
 <sub>The custom GUI above is reserved to educational purpose only.</sub>
 
+🚀 Quickstart
+-------------
+
+A SonarQube container image with ecoCode mobile embedded exists !
+
+```bash
+docker run -ti --rm \
+       -v sq_ecocode_mobile_logs:/opt/sonarqube/logs \
+       -v sq_ecocode_mobile_data:/opt/sonarqube/data \
+       -p 9000:9000 \
+       --name sonarqube-ecocode-mobile  \
+       --pull \
+       ghcr.io/green-code-initiative/sonarqube-ecocode-mobile:latest
+```
+
+Wait a little bit during first start initialization, and go to [http://localhost:9000](http://localhost:9000). Default credentials are `admin`/`admin`
+
+
 🤝 Partners
 ------------
 


### PR DESCRIPTION
Like [#72 on ecoCode](https://github.com/green-code-initiative/ecoCode/pull/72), this PR update the Dockerfile to build the plugins, and build a sonarqube container with plugins embedded.

A Github workflow is added too, in order to build new image on push and tag on main

To test it, you can use package built on my repo (I don’t have write access to green-code-initiative)

```bash
docker run -ti --rm \
       -v sq_ecocode_mobile_logs:/opt/sonarqube/logs \
       -v sq_ecocode_mobile_data:/opt/sonarqube/data \
       -p 9000:9000 \
       --name sonarqube-ecocode-mobile  \
       ghcr.io/obeone/sonarqube-ecocode-mobile:latest
```