### PR TITLE
Add ARM64v8 support to Dockerfile

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -17,6 +17,7 @@ env:
   IMAGE_NAME: sonarqube-ecocode-mobile
   IMAGES: |
     ghcr.io/${{ github.repository_owner }}/sonarqube-ecocode-mobile
+  PLATFORMS: linux/amd64,linux/arm64/v8
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -63,10 +64,12 @@ jobs:
             type=ref,event=pr
             type=sha
 
-      - name: Publish image
+      - name: Build and publish image
         id: push
         uses: docker/build-push-action@v4
         with:
+          context: .
+          platforms: ${{ env.PLATFORMS }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8-openjdk-11-slim AS builder
+FROM --platform=linux/amd64 maven:3.8-openjdk-11-slim AS builder
 
 COPY . /usr/src/ecocode
 


### PR DESCRIPTION
[Mirror PR of [https://github.com/green-code-initiative/ecoCode/pull/95](https://github.com/green-code-initiative/ecoCode/pull/95)]


With this PR, jar are built on amd64, and put in arm64v8 and amd64 SonarQube containers. There are two main advantages :
- Maven is not available on arm64v8, so it’s functional workaround
- jar are built once, so power consumption is as low as possible

To be able to build locally on Apple M*, you need to use buildkit (buildx), like :

```shell
docker buildx create --use # If you don’t already have a builder
docker buildx build --load .
```

Github workflow is updated to build both platform