### PR TITLE
[iOS] Power - Save mode awareness (EPOW002)

### DIFF
--- a/ios-plugin/RULES.md
+++ b/ios-plugin/RULES.md
@@ -9,7 +9,6 @@ Only one rule have been already implemented in the plugin. Table of unimplemente
 | # | **Rule Name**      |     **Scanner**     |      **Observation**     |
 |---|:----------------|:-------------:|:-------------:|
 | EIDL002 | Rigid Alarm | Swift | |
-| EPOW002 | Save Mode Awareness | Swift | |
 | ESOB002 | Thrifty Geolocation | Swift | |
 | ESOB003 | Motion Sensor Update Rate | Swift | |
 | ESOB004 | Disabled Dark Mode | Xml | Plist scanning |

--- a/ios-plugin/swift-lang/src/main/java/io/ecocode/ios/swift/checks/power/SaveModeAwarenessCheck.java
+++ b/ios-plugin/swift-lang/src/main/java/io/ecocode/ios/swift/checks/power/SaveModeAwarenessCheck.java
@@ -1,0 +1,53 @@
+/*
+ * ecoCode iOS plugin - Help the earth, adopt this green plugin for your applications
+ * Copyright © 2022 Green code Initiative (https://www.ecocode.io/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.ecocode.ios.swift.checks.power;
+
+import io.ecocode.ios.checks.RuleCheck;
+import io.ecocode.ios.swift.RegisterRule;
+import io.ecocode.ios.swift.Swift;
+import io.ecocode.ios.swift.antlr.generated.Swift5Parser;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+import java.util.List;
+
+@RegisterRule
+public class SaveModeAwarenessCheck extends RuleCheck {
+    public SaveModeAwarenessCheck() {
+        super("EPOW002", Swift.RULES_PATH, Swift.REPOSITORY_KEY);
+    }
+
+    private static final String PROCESS_INFO = "ProcessInfo.processInfo.isLowPowerModeEnabled";
+    private static final String POWER_STATE_NOTIFICATION_FULL = "Notification.Name.NSProcessInfoPowerStateDidChange";
+    private static final String POWER_STATE_NOTIFICATION_SHORT = ".NSProcessInfoPowerStateDidChange";
+
+    private static final List<String> EXPRESSIONS_TO_CHECK = List.of(
+        PROCESS_INFO,
+        POWER_STATE_NOTIFICATION_FULL,
+        POWER_STATE_NOTIFICATION_SHORT
+    );
+
+    @Override
+    public void apply(ParseTree tree) {
+        if (tree instanceof Swift5Parser.Postfix_expressionContext) {
+            Swift5Parser.Postfix_expressionContext id = (Swift5Parser.Postfix_expressionContext) tree;
+            if (EXPRESSIONS_TO_CHECK.contains(id.getText())) {
+                this.recordIssue(ruleId, id.getStart().getStartIndex());
+            }
+        }
+    }
+}

--- a/ios-plugin/swift-lang/src/main/resources/EPOW002.html
+++ b/ios-plugin/swift-lang/src/main/resources/EPOW002.html
@@ -1,0 +1,19 @@
+<img src="http://www.neomades.com/extern/partage/ecoCode/5sur5_1x.png">
+<p>Use device API to check if low power mode is enabled, and adapt resources usage accordingly.
+    For example, you can reduce frequency of data update if low power mode is enabled.
+    Your app can query the <code>ProcessInfo.processInfo.isLowPowerModeEnabled</code> property at any time
+    to determine whether Low Power Mode is active. Your app can also register to receive notifications
+    when the Low Power Mode state of a device changes, using <code>NSProcessInfoPowerStateDidChange</code>.
+</p>
+<h2>Compliant Code Example</h2>
+<pre>
+    let isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+</pre>
+OR
+<pre>
+    NotificationCenter.default.addObserver(forName: .NSProcessInfoPowerStateDidChange, object: nil, queue: nil) { _ in }
+</pre>
+OR
+<pre>
+    NotificationCenter.default.addObserver(forName: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil, queue: nil) { _ in }
+</pre>

--- a/ios-plugin/swift-lang/src/main/resources/ecocode-swift-rules.json
+++ b/ios-plugin/swift-lang/src/main/resources/ecocode-swift-rules.json
@@ -38,6 +38,23 @@
         "name": "Charge Awareness",
         "severity": "INFO",
         "description": "Monitoring power changes and customizing behavior depending on battery level is a good practice.",
+      "debt": {
+        "function": "CONSTANT_ISSUE",
+        "offset": "0min"
+      },
+      "tags": [
+        "ecocode",
+        "environment",
+        "power",
+        "eco-design"
+      ],
+      "type": "CODE_SMELL",
+    },
+    {
+        "key": "EPOW002",
+        "name": "Save Mode Awareness",
+        "severity": "INFO",
+        "description": "Taking into account when the device is entering or exiting the power save mode is a good practice.",
         "debt": {
             "function": "CONSTANT_ISSUE",
             "offset": "0min"

--- a/ios-plugin/swift-lang/src/main/resources/ecocode_swift_profile.json
+++ b/ios-plugin/swift-lang/src/main/resources/ecocode_swift_profile.json
@@ -3,6 +3,7 @@
   "ruleKeys": [
     "EIDL001",
     "EPOW001",
+    "EPOW002",
     "ESOB001",
     "ESOB005"
   ]

--- a/ios-plugin/swift-lang/src/test/java/io/ecocode/ios/swift/checks/power/SaveModeAwarenessCheckTest.java
+++ b/ios-plugin/swift-lang/src/test/java/io/ecocode/ios/swift/checks/power/SaveModeAwarenessCheckTest.java
@@ -1,0 +1,63 @@
+/*
+ * ecoCode iOS plugin - Help the earth, adopt this green plugin for your applications
+ * Copyright © 2022 Green code Initiative (https://www.ecocode.io/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.ecocode.ios.swift.checks.power;
+
+import io.ecocode.ios.swift.checks.CheckTestHelper;
+import org.junit.Test;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.batch.sensor.issue.IssueLocation;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class SaveModeAwarenessCheckTest {
+    @Test
+    public void saveModeAwareness_processInfo_trigger() {
+        saveModeAwareness_trigger("checks/power/SaveModeAwareness_ProcessInfo_trigger.swift", 11);
+    }
+
+    @Test
+    public void saveModeAwareness_powerStateNotification_trigger() {
+        saveModeAwareness_trigger("checks/power/SaveModeAwareness_PowerStateNotification_trigger.swift", 11);
+    }
+
+    @Test
+    public void saveModeAwareness_powerStateNotificationShort_trigger() {
+        saveModeAwareness_trigger("checks/power/SaveModeAwareness_PowerStateNotificationShort_trigger.swift", 11);
+    }
+
+    @Test
+    public void saveModeAwareness_no_trigger() {
+        SensorContextTester context = CheckTestHelper.analyzeTestFile("checks/power/SaveModeAwareness_no_trigger.swift");
+        assertThat(context.allIssues()).isEmpty();
+    }
+
+    private void saveModeAwareness_trigger(String filePath, int lineNumber) {
+        SensorContextTester context = CheckTestHelper.analyzeTestFile(filePath);
+        assertThat(context.allIssues()).hasSize(1);
+        Optional<Issue> issue = context.allIssues().stream().findFirst();
+        issue.ifPresent(i -> {
+            assertThat(i.ruleKey().rule()).isEqualTo("EPOW002");
+            assertThat(i.ruleKey().repository()).isEqualTo("ecoCode-swift");
+            IssueLocation location = i.primaryLocation();
+            assertThat(location.textRange().start().line()).isEqualTo(lineNumber);
+        });
+    }
+}

--- a/ios-plugin/swift-lang/src/test/resources/checks/power/SaveModeAwareness_PowerStateNotificationShort_trigger.swift
+++ b/ios-plugin/swift-lang/src/test/resources/checks/power/SaveModeAwareness_PowerStateNotificationShort_trigger.swift
@@ -1,0 +1,15 @@
+import Foundation
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+
+        // Should trigger
+        NotificationCenter.default.addObserver(forName: .NSProcessInfoPowerStateDidChange, object: nil, queue: nil) { _ in }
+
+        return true
+    }
+}

--- a/ios-plugin/swift-lang/src/test/resources/checks/power/SaveModeAwareness_PowerStateNotification_trigger.swift
+++ b/ios-plugin/swift-lang/src/test/resources/checks/power/SaveModeAwareness_PowerStateNotification_trigger.swift
@@ -1,0 +1,15 @@
+import Foundation
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+
+        // Should trigger
+        NotificationCenter.default.addObserver(forName: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil, queue: nil) { _ in }
+
+        return true
+    }
+}

--- a/ios-plugin/swift-lang/src/test/resources/checks/power/SaveModeAwareness_ProcessInfo_trigger.swift
+++ b/ios-plugin/swift-lang/src/test/resources/checks/power/SaveModeAwareness_ProcessInfo_trigger.swift
@@ -1,0 +1,15 @@
+import Foundation
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+
+        // Should trigger
+        let isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+
+        return true
+    }
+}

--- a/ios-plugin/swift-lang/src/test/resources/checks/power/SaveModeAwareness_no_trigger.swift
+++ b/ios-plugin/swift-lang/src/test/resources/checks/power/SaveModeAwareness_no_trigger.swift
@@ -1,0 +1,14 @@
+import Foundation
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+
+        // Should not trigger
+
+        return true
+    }
+}


### PR DESCRIPTION
# Description

Use device API to check if low power mode is enabled, and adapt resources usage accordingly. For example, you can reduce frequency of data update if low power mode is enabled. Your app can query the `ProcessInfo.processInfo.isLowPowerModeEnabled` property at any time to determine whether Low Power Mode is active. Your app can also register to receive notifications when the Low Power Mode state of a device changes, using `NSProcessInfoPowerStateDidChange`.