### PR TITLE
[iOS] Idleness - Rigid Alarm (EIDL002)

### DIFF
--- a/ios-plugin/RULES.md
+++ b/ios-plugin/RULES.md
@@ -8,7 +8,6 @@ Only one rule have been already implemented in the plugin. Table of unimplemente
 
 | # | **Rule Name**      |     **Scanner**     |      **Observation**     |
 |---|:----------------|:-------------:|:-------------:|
-| EIDL002 | Rigid Alarm | Swift | |
 | ESOB002 | Thrifty Geolocation | Swift | |
 | ESOB003 | Motion Sensor Update Rate | Swift | |
 | ESOB004 | Disabled Dark Mode | Xml | Plist scanning |

--- a/ios-plugin/swift-lang/src/main/java/io/ecocode/ios/swift/checks/idleness/RigidAlarmCheck.java
+++ b/ios-plugin/swift-lang/src/main/java/io/ecocode/ios/swift/checks/idleness/RigidAlarmCheck.java
@@ -22,13 +22,6 @@ import io.ecocode.ios.swift.Swift;
 import io.ecocode.ios.swift.antlr.generated.Swift5Parser;
 import io.ecocode.ios.checks.RuleCheck;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.TerminalNode;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
-
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Check the presence of the class "Timer".

--- a/ios-plugin/swift-lang/src/main/java/io/ecocode/ios/swift/checks/idleness/RigidAlarmCheck.java
+++ b/ios-plugin/swift-lang/src/main/java/io/ecocode/ios/swift/checks/idleness/RigidAlarmCheck.java
@@ -1,0 +1,53 @@
+/*
+ * ecoCode iOS plugin - Help the earth, adopt this green plugin for your applications
+ * Copyright © 2022 Green code Initiative (https://www.ecocode.io/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.ecocode.ios.swift.checks.idleness;
+
+import io.ecocode.ios.swift.RegisterRule;
+import io.ecocode.ios.swift.Swift;
+import io.ecocode.ios.swift.antlr.generated.Swift5Parser;
+import io.ecocode.ios.checks.RuleCheck;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Check the presence of the class "Timer".
+ */
+@RegisterRule
+public class RigidAlarmCheck extends RuleCheck {
+
+    public RigidAlarmCheck() {
+        super("EIDL002", Swift.RULES_PATH, Swift.REPOSITORY_KEY);
+    }
+
+    @Override
+    public void apply(ParseTree tree) {
+        if (tree instanceof Swift5Parser.IdentifierContext) {
+            Swift5Parser.IdentifierContext id = (Swift5Parser.IdentifierContext) tree;
+            if (id.getText().equals("Timer")) {
+                this.recordIssue(ruleId, id.getStart().getStartIndex());
+            }
+        }
+    }
+
+}

--- a/ios-plugin/swift-lang/src/main/resources/EIDL002.html
+++ b/ios-plugin/swift-lang/src/main/resources/EIDL002.html
@@ -1,0 +1,17 @@
+<img src="http://www.neomades.com/extern/partage/ecoCode/2sur5_1x.png">
+<p>Setting a tolerance for timers will allow them to fire later than the scheduled fire date.
+    The system will use this flexibility to shift the execution of timers by small amounts of time,
+    within their tolerances, increasing the ability to optimize power savings.
+    Your app can set the <code>Timer#tolerance</code> property to specify a tolerance for a timer.
+    Using this approach dramatically increases the amount of time that the processor spends idling
+    while users detect no change in system responsiveness.
+</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+    let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in }
+</pre>
+<h2>Compliant Code Example</h2>
+<pre>
+    let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in }
+    timer.tolerance = 0.5
+</pre>

--- a/ios-plugin/swift-lang/src/main/resources/ecocode-swift-rules.json
+++ b/ios-plugin/swift-lang/src/main/resources/ecocode-swift-rules.json
@@ -34,6 +34,23 @@
         "type": "CODE_SMELL"
     },
     {
+        "key": "EIDL002",
+        "name": "Rigid Alarm",
+        "severity": "MAJOR",
+        "description": "Setting a tolerance for timers will allow them to fire later than the scheduled fire date.",
+        "debt": {
+            "function": "CONSTANT_ISSUE",
+            "offset": "1min"
+        },
+        "tags": [
+            "ecocode",
+            "environment",
+            "idleness",
+            "eco-design"
+        ],
+        "type": "CODE_SMELL"
+    },
+    {
         "key": "EPOW001",
         "name": "Charge Awareness",
         "severity": "INFO",

--- a/ios-plugin/swift-lang/src/main/resources/ecocode_swift_profile.json
+++ b/ios-plugin/swift-lang/src/main/resources/ecocode_swift_profile.json
@@ -2,6 +2,7 @@
   "name": "ecoCode",
   "ruleKeys": [
     "EIDL001",
+    "EIDL002",
     "EPOW001",
     "EPOW002",
     "ESOB001",

--- a/ios-plugin/swift-lang/src/test/java/io/ecocode/ios/swift/checks/idleness/RigidAlarmCheckTest.java
+++ b/ios-plugin/swift-lang/src/test/java/io/ecocode/ios/swift/checks/idleness/RigidAlarmCheckTest.java
@@ -1,0 +1,51 @@
+/*
+ * ecoCode iOS plugin - Help the earth, adopt this green plugin for your applications
+ * Copyright © 2022 Green code Initiative (https://www.ecocode.io/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.ecocode.ios.swift.checks.idleness;
+
+import io.ecocode.ios.swift.checks.CheckTestHelper;
+import org.junit.Test;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.Issue;
+import org.sonar.api.batch.sensor.issue.IssueLocation;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class RigidAlarmCheckTest {
+
+    @Test
+    public void rigidAlarmCheck_no_trigger() {
+        SensorContextTester context = CheckTestHelper.analyzeTestFile("checks/idleness/RigidAlarmCheck_no_trigger.swift");
+        assertThat(context.allIssues()).isEmpty();
+    }
+
+    @Test
+    public void rigidAlarmCheck_trigger() {
+        SensorContextTester context = CheckTestHelper.analyzeTestFile("checks/idleness/RigidAlarmCheck_trigger.swift");
+        assertThat(context.allIssues()).hasSize(1);
+        Optional<Issue> issue = context.allIssues().stream().findFirst();
+        issue.ifPresent(i -> {
+            assertThat(i.ruleKey().rule()).isEqualTo("EIDL002");
+            assertThat(i.ruleKey().repository()).isEqualTo("ecoCode-swift");
+            IssueLocation location = i.primaryLocation();
+            assertThat(location.textRange().start().line()).isEqualTo(11);
+        });
+    }
+
+}

--- a/ios-plugin/swift-lang/src/test/resources/checks/idleness/RigidAlarmCheck_no_trigger.swift
+++ b/ios-plugin/swift-lang/src/test/resources/checks/idleness/RigidAlarmCheck_no_trigger.swift
@@ -1,0 +1,14 @@
+import Foundation
+import SwiftUI
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+
+        // Should not trigger
+
+        return true
+    }
+}

--- a/ios-plugin/swift-lang/src/test/resources/checks/idleness/RigidAlarmCheck_trigger.swift
+++ b/ios-plugin/swift-lang/src/test/resources/checks/idleness/RigidAlarmCheck_trigger.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftUI
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+
+        // Should trigger
+        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in }
+
+        return true
+    }
+}


### PR DESCRIPTION
# Description

Setting a tolerance for timers will allow them to fire later than the scheduled fire date. The system will use this flexibility to shift the execution of timers by small amounts of time, within their tolerances, increasing the ability to optimize power savings. Your app can set the `Timer#tolerance` property to specify a tolerance for a timer. Using this approach dramatically increases the amount of time that the processor spends idling while users detect no change in system responsiveness.